### PR TITLE
Blackcoin More v13.2.1 upgrade

### DIFF
--- a/org.blackcoin.blackcoin-more.json
+++ b/org.blackcoin.blackcoin-more.json
@@ -54,8 +54,7 @@
         },
         {
           "type": "file",
-          "path": "org.blackcoin.blackcoin-more.metainfo.xml",
-          "sha256": "e62735c0404bd8785f7fee0a17d2b70bbd6d20ce7e5cfeaea0da5cab8d1ea11c"
+          "path": "org.blackcoin.blackcoin-more.metainfo.xml"
         },
         {
           "type": "file",

--- a/org.blackcoin.blackcoin-more.json
+++ b/org.blackcoin.blackcoin-more.json
@@ -26,13 +26,13 @@
           "type": "archive",
           "only-arches": ["x86_64"],
           "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-x86_64-linux-gnu.tar.gz",
-          "sha256": "2b078ca9f1b98b49daae82e11f413210aaaa18dc9605c102007c0eeef0a9bccf"
+          "sha256": "3681da3217019e202b887ab5d34f2a5ad3a1dd98368d3c7362f72753c0722184"
         },
         {
           "type": "archive",
           "only-arches": ["aarch64"],
           "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-aarch64-linux-gnu.tar.gz",
-          "sha256": "f6b5772474d3a501a61072acd81eea3ed2bc2623e5c8ecfde42f80472c925395"
+          "sha256": "bd2a5f0cacfe170cdae814f64e41f1904a08911da4b09629b2441d74166dc780"
         }
       ]
     },

--- a/org.blackcoin.blackcoin-more.json
+++ b/org.blackcoin.blackcoin-more.json
@@ -25,14 +25,14 @@
         {
           "type": "archive",
           "only-arches": ["x86_64"],
-          "url": "https://github.com/expatjedi/blk-flatpak-data/releases/download/13.2.0/blackcoin-more-13.2.0-x86_64-linux-gnu.tar.gz",
-          "sha256": "e73c68fd4a35cc7d629f62ccfb265be5b3fa259b162d28c31d15cf6228a8a90a"
+          "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-x86_64-linux-gnu.tar.gz",
+          "sha256": "e2534da986cfd9f9747d206bbf7618e99c85bf854d3793363493523d3dac8964"
         },
         {
           "type": "archive",
           "only-arches": ["aarch64"],
-          "url": "https://github.com/expatjedi/blk-flatpak-data/releases/download/13.2.0/blackcoin-more-13.2.0-aarch64-linux-gnu.tar.gz",
-          "sha256": "9816fa0772068b55686dda6e1c0eda276942980bfa53ee47495fee6a001311e8"
+          "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-aarch64-linux-gnu.tar.gz",
+          "sha256": "c5138cefe0cd07aa241afe8fc72a54c167cb3e2dab444207bb6f754e1b97176b"
         }
       ]
     },

--- a/org.blackcoin.blackcoin-more.json
+++ b/org.blackcoin.blackcoin-more.json
@@ -55,7 +55,7 @@
         {
           "type": "file",
           "path": "org.blackcoin.blackcoin-more.metainfo.xml",
-          "sha256": "e801d9101218916652694249f1915b31d256a2ad8efff94ab5843f4fa17455ff"
+          "sha256": "e62735c0404bd8785f7fee0a17d2b70bbd6d20ce7e5cfeaea0da5cab8d1ea11c"
         },
         {
           "type": "file",

--- a/org.blackcoin.blackcoin-more.json
+++ b/org.blackcoin.blackcoin-more.json
@@ -26,13 +26,13 @@
           "type": "archive",
           "only-arches": ["x86_64"],
           "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-x86_64-linux-gnu.tar.gz",
-          "sha256": "87a9b38b12075bc80f2b5538b932bdf708e9e93ea290bf5288be1bdff895f649"
+          "sha256": "2b078ca9f1b98b49daae82e11f413210aaaa18dc9605c102007c0eeef0a9bccf"
         },
         {
           "type": "archive",
           "only-arches": ["aarch64"],
           "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-aarch64-linux-gnu.tar.gz",
-          "sha256": "77d0e8bd499d0f88033136f83269ef2d47a35f68fe5f3062ac8a4b4812f96aef"
+          "sha256": "f6b5772474d3a501a61072acd81eea3ed2bc2623e5c8ecfde42f80472c925395"
         }
       ]
     },

--- a/org.blackcoin.blackcoin-more.json
+++ b/org.blackcoin.blackcoin-more.json
@@ -26,13 +26,13 @@
           "type": "archive",
           "only-arches": ["x86_64"],
           "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-x86_64-linux-gnu.tar.gz",
-          "sha256": "e2534da986cfd9f9747d206bbf7618e99c85bf854d3793363493523d3dac8964"
+          "sha256": "87a9b38b12075bc80f2b5538b932bdf708e9e93ea290bf5288be1bdff895f649"
         },
         {
           "type": "archive",
           "only-arches": ["aarch64"],
           "url": "https://github.com/CoinBlack/blackcoin-more/releases/download/v13.2.1/blackcoin-more-13.2.1-aarch64-linux-gnu.tar.gz",
-          "sha256": "c5138cefe0cd07aa241afe8fc72a54c167cb3e2dab444207bb6f754e1b97176b"
+          "sha256": "77d0e8bd499d0f88033136f83269ef2d47a35f68fe5f3062ac8a4b4812f96aef"
         }
       ]
     },

--- a/org.blackcoin.blackcoin-more.metainfo.xml
+++ b/org.blackcoin.blackcoin-more.metainfo.xml
@@ -3,7 +3,7 @@
   <id>org.blackcoin.blackcoin-more</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
-  <name>Blackcoin</name>
+  <name>Blackcoin More</name>
   <summary>True Decentralised Digital Currency.</summary>
   <description>
     <p>
@@ -22,7 +22,7 @@
   <update_contact>team@blackcoin.org</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
-    <release date="2022-11-25" version="13.2.0" />
+    <release date="2023-07-04" version="13.2.1" />
     <release date="2022-02-24" version="2.13.2.9" />
     </releases>
 </component>


### PR DESCRIPTION
This PR is for the upgrade of our Blackcoin More software package to version v13.2.1

More info can be found here:
- https://github.com/CoinBlack/blackcoin-more/releases/tag/v13.2.1
- https://gitlab.com/blackcoin/blackcoin-more/-/releases/v13.2.1
- https://blackcoinmore.org

Packages are now used from the official Blackcoin Repo 